### PR TITLE
fix for not taking into account route variables

### DIFF
--- a/flaskext/paginate.py
+++ b/flaskext/paginate.py
@@ -95,7 +95,7 @@ class Pagination(object):
 
     @property
     def args(self):
-        args = request.args.to_dict()
+        args = dict(request.args.to_dict().items() + request.view_args.items())
         args.pop('page', None)
         return args
 


### PR DESCRIPTION
currently flask-paginate does not properly handle pagination for pages of this sort
/user/int:id/page/int:page

it'll error out because id is not passed along (as it doesn't show up in args and doesn't show up in endpoint).

this fix fixes this by adding in view_args to args, which is where the route information (e.g. id in this example) shows up.
