### PR TITLE
Fix pagination navigation while searching

### DIFF
--- a/flask_paginate/__init__.py
+++ b/flask_paginate/__init__.py
@@ -96,7 +96,8 @@ class Pagination(object):
 
     @property
     def total_pages(self):
-        pages = divmod(self.total, self.per_page)
+        current_total = self.found if self.search else self.total
+        pages = divmod(current_total, self.per_page)
         return pages[0] + 1 if pages[1] else pages[0]
 
     @property


### PR DESCRIPTION
Pagination wasn't taking into account "found" variable while assembling the navigation links when the current mode was "search".
