### PR TITLE
Replacing dict to werkzeug.datastructures.MultiDict for request args in ...

### DIFF
--- a/flask_paginate/__init__.py
+++ b/flask_paginate/__init__.py
@@ -13,6 +13,7 @@
 
 from __future__ import unicode_literals
 from flask import request, url_for
+from werkzeug.datastructures import MultiDict
 
 _bs_prev_page = '<li class="previous"><a href="{0}">{1}</a></li>'
 PREV_PAGES = dict(bootstrap=_bs_prev_page,
@@ -182,7 +183,7 @@ class Pagination(object):
 
     @property
     def args(self):
-        args = dict(request.args.to_dict().items() + request.view_args.items())
+        args = MultiDict(list(request.args.iteritems(multi=True)) + request.view_args.items())
         args.pop('page', None)
         return args
 


### PR DESCRIPTION
Support for multiselect, multiple checkboxes with the same name attribute in html. For example: in my first page with some list of users with phone numbers, I has a multiple select input field for filter users by phone numbers. The request args string after filtering looks like: "?phones=1234567&phones=7654321&phones=5673212", but in paginate links href attribute I has only one phone since the python dict type does not support non-unique keys. To solve this problem you can use a MultiDict structure from werkzeug.datastructures instead of the standard dictionary python type.
