### PR TITLE
Added page_parameter

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -5,7 +5,7 @@ flask-paginate |release| documentation
 
 Overview
 ---------
-Latest version: **0.4.4**
+Latest version: **0.4.5**
 
 **flask-paginate** is a simple paginate extension for
 `flask`_ which is reference to `will_paginate`_,
@@ -157,6 +157,10 @@ Below are the params for **Pagination.__init__()**, you can change the settings 
 
     **per_page**: how many records displayed on one page
 
+    **page_parameter**: a name(string) of a GET parameter that holds 
+    a page index. Use it if you want to iterate over multiple Pagination 
+    objects simultaniously.
+
     **inner_window**: how many links arround current page
 
     **outer_window**: how many links near first/last link
@@ -180,7 +184,7 @@ Below are the params for **Pagination.__init__()**, you can change the settings 
     **alignment**: the alignment of pagination links
 
     **href**: Add custom href for links - this supports forms \
-    with post method
+    with post method. MUST contain {0} to format page number
 
     **show_single_page**: decide whether or not a single page \
     returns pagination
@@ -188,9 +192,6 @@ Below are the params for **Pagination.__init__()**, you can change the settings 
     **bs_version**: the version of bootstrap, default is **2**
 
     **css_framework**: the css framework, default is **bootstrap**
-
-    **href**: <a> href parameter, MUST contain {0} to format \
-    page number
 
     **anchor**: anchor parameter, appends to page href
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -224,10 +224,15 @@ Contributors
 - `trein <https://github.com/trein>`_
 - `tark-hidden <https://github.com/tark-hidden>`_
 - `wong2 <https://github.com/wong2>`_
-
+- `voltterra <https://github.com/voltterra>`_
 
 Changelog
 ---------
+Version 0.4.5
+-------------
+Added new parameter `page_parameter` to simultaniously interate over multiple Pagination objects.
+See documentation
+
 Version 0.4.4
 -------------
 

--- a/flask_paginate/__init__.py
+++ b/flask_paginate/__init__.py
@@ -94,7 +94,8 @@ F_ALIGNMENT = '<div class="pagination-{0}">'
 def get_page_args():
     args = request.args.copy()
     args.update(request.view_args.copy())
-    page = int(args.get('page', 1))
+    page_parameter = args.get('page_parameter', 'page')
+    page = int(args.get(page_parameter, 1))
     per_page = args.get('per_page')
     if not per_page:
         per_page = current_app.config.get('PER_PAGE', 10)
@@ -116,6 +117,11 @@ class Pagination(object):
             **page**: current page
 
             **per_page**: how many records displayed on one page
+
+            **page_parameter**: a name(string) of a GET parameter that holds \
+            a page index, Use it if you want to iterate over multiple Pagination \
+            objects simultaniously.
+            default is 'page'.
 
             **inner_window**: how many links arround current page
 
@@ -140,10 +146,7 @@ class Pagination(object):
             **alignment**: the alignment of pagination links
 
             **href**: Add custom href for links - this supports forms \
-            with post method;
-
-            **href**: <a> href parameter, MUST contain {0} to format \
-            page number
+            with post method. It MUST contain {0} to format page number
 
             **show_single_page**: decide whether or not a single page \
             returns pagination
@@ -151,7 +154,6 @@ class Pagination(object):
             **bs_version**: the version of bootstrap, default is **2**
 
             **css_framework**: the css framework, default is **bootstrap**
-
 
             **anchor**: anchor parameter, appends to page href
 
@@ -161,13 +163,10 @@ class Pagination(object):
             **format_number**: number format start and end, like **1,234**, \
             default is False
 
-            **page_parameter**: a name(string) of a GET parameter that holds a page index\
-            default is 'page'. Usage: page = int(request.args.get('page_parameter'))
-            Pagination(page_parameter = page_parameter, page=page, **args)
         '''
         self.found = found
-        self.page = kwargs.get('page', 1)
         self.page_parameter = kwargs.get('page_parameter', 'page')
+        self.page = kwargs.get(self.page_parameter, 1)
         self.per_page = kwargs.get('per_page', 10)
         self.inner_window = kwargs.get('inner_window', 2)
         self.outer_window = kwargs.get('outer_window', 1)
@@ -214,6 +213,10 @@ class Pagination(object):
         self.next_page_fmt = NEXT_PAGES[self.css_framework]
         self.css_end_fmt = CSS_LINKS_END[self.css_framework]
         self.init_values()
+
+        print "\n" * 4
+        print self.page
+        print "\n" * 4
 
     def page_href(self, page):
         if self.href:

--- a/flask_paginate/__init__.py
+++ b/flask_paginate/__init__.py
@@ -15,7 +15,7 @@ from __future__ import unicode_literals
 import sys
 from flask import request, url_for, Markup, current_app
 
-__version__ = '0.4.2'
+__version__ = '0.4.5'
 
 PY2 = sys.version_info[0] == 2
 
@@ -140,7 +140,10 @@ class Pagination(object):
             **alignment**: the alignment of pagination links
 
             **href**: Add custom href for links - this supports forms \
-            with post method
+            with post method;
+
+            **href**: <a> href parameter, MUST contain {0} to format \
+            page number
 
             **show_single_page**: decide whether or not a single page \
             returns pagination
@@ -149,8 +152,6 @@ class Pagination(object):
 
             **css_framework**: the css framework, default is **bootstrap**
 
-            **href**: <a> href parameter, MUST contain {0} to format \
-            page number
 
             **anchor**: anchor parameter, appends to page href
 
@@ -159,9 +160,14 @@ class Pagination(object):
 
             **format_number**: number format start and end, like **1,234**, \
             default is False
+
+            **page_parameter**: a name(string) of a GET parameter that holds a page index\
+            default is 'page'. Usage: page = int(request.args.get('page_parameter'))
+            Pagination(page_parameter = page_parameter, page=page, **args)
         '''
         self.found = found
         self.page = kwargs.get('page', 1)
+        self.page_parameter = kwargs.get('page_parameter', 'page')
         self.per_page = kwargs.get('per_page', 10)
         self.inner_window = kwargs.get('inner_window', 2)
         self.outer_window = kwargs.get('outer_window', 1)
@@ -213,7 +219,7 @@ class Pagination(object):
         if self.href:
             url = self.href.format(page or 1)
         else:
-            self.args.update(page=page)
+            self.args[self.page_parameter] = page
             if self.anchor:
                 url = url_for(self.endpoint, _anchor=self.anchor, **self.args)
             else:

--- a/flask_paginate/__init__.py
+++ b/flask_paginate/__init__.py
@@ -214,10 +214,6 @@ class Pagination(object):
         self.css_end_fmt = CSS_LINKS_END[self.css_framework]
         self.init_values()
 
-        print "\n" * 4
-        print self.page
-        print "\n" * 4
-
     def page_href(self, page):
         if self.href:
             url = self.href.format(page or 1)

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ from setuptools import setup
 
 setup(
     name='flask-paginate',
-    version='0.4.4',
+    version='0.4.5',
     url='https://github.com/lixxu/flask-paginate',
     license='BSD',
     author='Lix Xu',


### PR DESCRIPTION
I added a new page_name_parameter that allows you to have a custom name for the page GET parameter, not just ?page=1
Use case: you can iterate over two(possibly more) paginator objects on a generated page simultaneously.
`page = int(request.args.get(page_parameter, 1)
Paginator(page=page, page_parameter=page_parameter, **args)`