### PR TITLE
Add python3.7 classifier

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -46,5 +46,6 @@ setup(
         'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
+        'Programming Language :: Python :: 3.7',
     ]
 )


### PR DESCRIPTION
`
============================= test session starts ==============================
platform linux -- Python 3.7.3, pytest-4.5.0, py-1.5.4, pluggy-0.11.0 -- /usr/bin/python3.7
cachedir: .pytest_cache
rootdir: /home/test_user/Develop/Projects/flask-paginate
collecting ... collected 7 items

tests.py::TestGetPageArgs::test_get_page_args_fails_outside_of_request_context PASSED [ 14%]
tests.py::TestGetPageArgs::test_get_page_args_works_inside_of_request_context PASSED [ 28%]
tests.py::TestPagination::test_customize_page_parameter PASSED           [ 42%]
tests.py::TestPagination::test_customize_per_page_parameter PASSED       [ 57%]
tests.py::TestPagination::test_defaults PASSED                           [ 71%]
tests.py::TestPagination::test_pages_first_page PASSED                   [ 85%]
tests.py::TestPagination::test_pages_outer_window_0 PASSED               [100%]

=============================== warnings summary ===============================
/home/test_user/.local/lib/python3.7/site-packages/Jinja2-2.10.1-py3.7.egg/jinja2/utils.py:485
  /home/test_user/.local/lib/python3.7/site-packages/Jinja2-2.10.1-py3.7.egg/jinja2/utils.py:485: DeprecationWarning: Using or importing the ABCs from 'collections' instead of from 'collections.abc' is deprecated, and in 3.8 it will stop working
    from collections import MutableMapping

/home/test_user/.local/lib/python3.7/site-packages/Jinja2-2.10.1-py3.7.egg/jinja2/runtime.py:318
  /home/test_user/.local/lib/python3.7/site-packages/Jinja2-2.10.1-py3.7.egg/jinja2/runtime.py:318: DeprecationWarning: Using or importing the ABCs from 'collections' instead of from 'collections.abc' is deprecated, and in 3.8 it will stop working
    from collections import Mapping

-- Docs: https://docs.pytest.org/en/latest/warnings.html
===================== 7 passed, 2 warnings in 0.10 seconds =====================
`