### PR TITLE
include LICENSE in manifest

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,3 +1,5 @@
 graft docs tests
 global-exclude __pycache__
 global-exclude *.py[co]
+
+include LICENSE


### PR DESCRIPTION
So the license is included in the pip package. 