### PR TITLE
Fix page and per page assignment

### DIFF
--- a/flask_paginate/__init__.py
+++ b/flask_paginate/__init__.py
@@ -310,13 +310,13 @@ class Pagination(object):
             page_parameter = get_page_parameter()
 
         self.page_parameter = page_parameter
-        self.page = kwargs.get(self.page_parameter, 1)
+        self.page = kwargs.get("page", 1)
         per_page_param = kwargs.get("per_page_parameter")
         if not per_page_param:
             per_page_param = get_per_page_parameter()
 
         self.per_page_parameter = per_page_param
-        self.per_page = kwargs.get(per_page_param, 10)
+        self.per_page = kwargs.get("per_page", 10)
         self.skip = (self.page - 1) * self.per_page
         self.inner_window = kwargs.get("inner_window", 2)
         self.outer_window = kwargs.get("outer_window", 1)


### PR DESCRIPTION
In the class Pagination in constructor there was an assignment of variables page and per_page. They were assigned with the help of kwargs.get.
The problem was that kwargs.get was getting a per_page_param/page_parameter variable rather than the actual string specified in docstring ("page" and "per_page")

This commit fixes that issue.