### PR TITLE
update __init__.py to fix negative page issues

### DIFF
--- a/flask_paginate/__init__.py
+++ b/flask_paginate/__init__.py
@@ -315,6 +315,10 @@ class Pagination(object):
 
         self.page_parameter = page_parameter
         self.page = int(kwargs.get(self.page_parameter, 1))
+        
+        if self.page < 1:
+            self.page = 1
+        
         per_page_param = kwargs.get("per_page_parameter")
         if not per_page_param:
             per_page_param = get_per_page_parameter()


### PR DESCRIPTION
<h3>When does the issue occur?</h3>
If you add an input tag in the html file with the attribute "name" the same as the name of page_parameter (default: name="page") it allows you to jump to the page written in the input. 

Example: 
`<input type="text" name="page" placeholder="Go to page...">`


<h3>What happens?</h3>
The problem is that if you input a negative number it will jump to the first page but pagination.info will be wrong and with negative numbers. 
Furthermore, even the indexes obtained with "{{ loop.index + pagination.skip }}" as per example in "example\templates\index.html" will be negative and wrong.

<br>
<h3>Solution</h3>
Defaulting self.page in Pagination.__init__() to 1 if it's negative fixes the issues.