### PR TITLE
Add type conversion for page and per_page args

### DIFF
--- a/flask_paginate/__init__.py
+++ b/flask_paginate/__init__.py
@@ -236,8 +236,8 @@ def get_page_args(
     if for_test:
         return page_name, per_page_name
 
-    page = int(args.get(page_name, 1))
-    per_page = args.get(per_page_name)
+    page = int(args.get(page_name, 1, type=int))
+    per_page = args.get(per_page_name, type=int)
     if not per_page:
         per_page = int(current_app.config.get(per_page_name.upper(), 10))
     else:


### PR DESCRIPTION
When string is passed to page or per_page args the following exception occurs:
`ValueError: invalid literal for int() with base 10: 'a'`

This commits adds type conversion to avoid that exception.