### PR TITLE
Port to Sphinx 8.0

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -277,4 +277,4 @@ texinfo_documents = [
 
 
 # Example configuration for intersphinx: refer to the Python standard library.
-intersphinx_mapping = {"http://docs.python.org/": None}
+intersphinx_mapping = {"python": ("http://docs.python.org/", None)}


### PR DESCRIPTION
The old `intersphinx_mapping` format has been removed; it must now map identifiers to (target, inventory) tuples.